### PR TITLE
Adding fallback for missing title to filename and <link> tag

### DIFF
--- a/templates/channel.rss.erb
+++ b/templates/channel.rss.erb
@@ -45,7 +45,7 @@
   <% end %>
   <% items.each{|item| %>
     <item>
-      <title><%= item.tag.title || item.tag2.TIT2%></title>
+      <title><%= item.tag.title || item.tag2.TIT2 || item.file_name%></title>
       <itunes:author><%= h(item.tag2.TP1 || item.tag2.TPE1) %></itunes:author>
     <% unless item.tag2.TT3.blank? %>
       <itunes:subtitle><%= h(truncate(item.tag2.TT3, 50)) %></itunes:subtitle>
@@ -53,6 +53,7 @@
     <% end %>
       <itunes:image href="<%= item.image_url %>"/>
       <enclosure url="<%= item.url %>" length="<%= item.file_size %>" type="audio/mp3"/>
+      <link><%= item.url %></link>
       <guid isPermaLink="false"><%= h(item.uuid) %></guid>
       <pubDate><%= h(item.pub_date.to_formatted_s(:rfc822)) %></pubDate>
       <itunes:duration><%= item.duration.to_i %></itunes:duration>


### PR DESCRIPTION
This allows the feed to be compatible with iTunes and the Podcasts stock app for iOS