### PR TITLE
Fix no-trailing-array-commas

### DIFF
--- a/test/bin/vagrant-status
+++ b/test/bin/vagrant-status
@@ -24,7 +24,7 @@ TYPES = [
   'provider-name',     # The provider name of the target machine. targeted
   'state',             # The state ID of the target machine. targeted
   'state-human-long',  # Human-readable description of the state of the machine. This is the long version, and may be a paragraph or longer. targeted
-  'state-human-short', # Human-readable description of the state of the machine. This is the short version, limited to at most a sentence. targeted
+  'state-human-short'  # Human-readable description of the state of the machine. This is the short version, limited to at most a sentence. targeted
 ].freeze
 
 module Vagrant


### PR DESCRIPTION
Fixes build failures when updating to rubocop 0.65.0 (https://github.com/nerab/dropcaster/pull/119)